### PR TITLE
Fix getTags() when properties is null

### DIFF
--- a/src/main/java/org/openstreetmap/josm/plugins/geojson/GeoJsonReader.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/geojson/GeoJsonReader.java
@@ -225,8 +225,8 @@ public class GeoJsonReader extends AbstractReader {
     private Map<String, String> getTags(final JsonObject feature) {
         final Map<String, String> tags = new TreeMap<>();
 
-        JsonObject properties = feature.getJsonObject(PROPERTIES);
-        if (properties != null) {
+        if (!feature.isNull(PROPERTIES)) {
+            JsonObject properties = feature.getJsonObject(PROPERTIES);
             for (Map.Entry<String, JsonValue> stringJsonValueEntry : properties.entrySet()) {
                 tags.put(stringJsonValueEntry.getKey(), String.valueOf(stringJsonValueEntry.getValue()));
             }


### PR DESCRIPTION
When properties is null, java.lang.ClassCastException is generated. This fixes the issue #14
```
java.lang.ClassCastException: javax.json.JsonValueImpl cannot be cast to javax.json.JsonObject
	at org.glassfish.json.JsonObjectBuilderImpl$JsonObjectImpl.getJsonObject(JsonObjectBuilderImpl.java:242)
	at org.openstreetmap.josm.plugins.geojson.GeoJsonReader.getTags(GeoJsonReader.java:228)
	at org.openstreetmap.josm.plugins.geojson.GeoJsonReader.fillTagsFromFeature(GeoJsonReader.java:217)
	at org.openstreetmap.josm.plugins.geojson.GeoJsonReader.parseLineString(GeoJsonReader.java:145)
	at org.openstreetmap.josm.plugins.geojson.GeoJsonReader.parseGeometry(GeoJsonReader.java:107)
	at org.openstreetmap.josm.plugins.geojson.GeoJsonReader.parseFeature(GeoJsonReader.java:88)
	at org.openstreetmap.josm.plugins.geojson.GeoJsonReader.parseFeatureCollection(GeoJsonReader.java:81)
	at org.openstreetmap.josm.plugins.geojson.GeoJsonReader.parseRoot(GeoJsonReader.java:64)
	at org.openstreetmap.josm.plugins.geojson.GeoJsonReader.parse(GeoJsonReader.java:55)
	at org.openstreetmap.josm.plugins.geojson.GeoJsonReader.doParseDataSet(GeoJsonReader.java:240)
	at org.openstreetmap.josm.plugins.geojson.GeoJsonFileImporter.importData(GeoJsonFileImporter.java:50)
	at org.openstreetmap.josm.gui.io.importexport.FileImporter.importDataHandleExceptions(FileImporter.java:95)
	at org.openstreetmap.josm.actions.OpenFileAction$OpenFileTask.importData(OpenFileAction.java:366)
	at org.openstreetmap.josm.actions.OpenFileAction$OpenFileTask.realRun(OpenFileAction.java:319)
	at org.openstreetmap.josm.gui.PleaseWaitRunnable.doRealRun(PleaseWaitRunnable.java:95)
	at org.openstreetmap.josm.gui.PleaseWaitRunnable.run(PleaseWaitRunnable.java:143)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```